### PR TITLE
Update dependencies for Node 20

### DIFF
--- a/M4L.MelodyVAE/M4L.MelodyVAE.maxproj
+++ b/M4L.MelodyVAE/M4L.MelodyVAE.maxproj
@@ -1816,7 +1816,7 @@
 
 			}
 ,
-			"node-pre-gyp" : 			{
+			"@mapbox/node-pre-gyp" : 			{
 				"kind" : "file",
 				"local" : 1,
 				"singleton" : 				{

--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@
 Max for Live(M4L) Melody generator using Variational Autoencoder(VAE) 
 
 A derivative of [RhythmVAE_M4l](https://github.com/naotokui/RhythmVAE_M4L)
+
+## Installation
+
+Install the npm dependencies from within Max for Live using `npm install`.
+
+**Important:** the build for `@tensorflow/tfjs-node` fails if the project is
+located in a path that contains spaces. Move the `melodyvae_m4l` directory to a
+location without spaces (or create a symlink) before running `npm install`.
+
+The project now depends on TensorFlow.js 4.x which includes pre-built
+binaries for Apple&nbsp;Silicon. Max 9 ships with Node&nbsp;20 and works
+with these versions. If you use your own Node installation, Node&nbsp;18 or
+newer is recommended.

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "license": "ISC",
   "dependencies": {
     "@magenta/music": "^1.23.1",
-    "@tensorflow/tfjs-node": "^3.11.0",
+    "@tensorflow/tfjs-node": "^4.22.0",
     "@tonejs/midi": "^2.0.7",
     "cross-fetch": "^3.0.4",
     "glob": "^7.1.4",
-    "node-pre-gyp": "^0.17.0",
+    "@mapbox/node-pre-gyp": "^1.0.9",
     "tiny-glob": "^0.2.6",
     "ws": "^6.2.2"
   },
@@ -24,8 +24,8 @@
     "electron-rebuild": "^3.2.9"
   },
   "overrides": {
-    "@tensorflow/tfjs-node": "^3.11.0",
-    "node-pre-gyp": "^0.17.0"
+    "@tensorflow/tfjs-node": "^4.22.0",
+    "@mapbox/node-pre-gyp": "^1.0.9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump `@tensorflow/tfjs-node` to 4.22.0 and switch to `@mapbox/node-pre-gyp`
- note Node 20 support in README
- update project file to reference the new dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687673210328832ca259370b7b3a9edc